### PR TITLE
add active model serializer class for bucketlist and item

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'jwt'
 gem "codeclimate-test-reporter", group: :test, require: nil
 gem 'bcrypt', '~> 3.1.7'
+gem 'active_model_serializers', '~> 0.10.0'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.10.2)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      jsonapi (~> 0.1.1.beta2)
+      railties (>= 4.1, < 6)
     activejob (4.2.7.1)
       activesupport (= 4.2.7.1)
       globalid (>= 0.3.0)
@@ -83,6 +88,11 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jsonapi (0.1.1.beta5)
+      jsonapi-parser (= 0.1.1.beta2)
+      jsonapi-renderer (= 0.1.1.beta1)
+    jsonapi-parser (0.1.1.beta2)
+    jsonapi-renderer (0.1.1.beta1)
     jwt (1.5.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -202,6 +212,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   bcrypt (~> 3.1.7)
   byebug
   capybara (~> 2.9, >= 2.9.1)

--- a/app/serializers/bucketlist_serializer.rb
+++ b/app/serializers/bucketlist_serializer.rb
@@ -1,0 +1,4 @@
+class BucketlistSerializer < ActiveModel::Serializer
+  attributes :id, :name, :created_at, :updated_at
+  has_many :items
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,3 @@
+class ItemSerializer < ActiveModel::Serializer
+  attributes :id, :name, :done, :created_at, :updated_at
+end


### PR DESCRIPTION
Active model Serializer gem is used to customize the json output when a resources is requested.
