### PR TITLE
add paginate method to bucketlist model

### DIFF
--- a/app/models/bucketlist.rb
+++ b/app/models/bucketlist.rb
@@ -7,9 +7,15 @@ class Bucketlist < ActiveRecord::Base
     where('lower(name) LIKE ?', "%#{keyword.downcase}%")
   end
   scope :recently_added, -> { order(:created_at) }
+  scope :paginate, ->(page, limit = 20) do
+    offset((page.to_i - 1) * limit.to_i).
+      limit(limit.to_i)
+  end
 
   def self.search(params = {})
-    return Bucketlist.all unless params[:q].present?
-    Bucketlist.filter_by_name(params[:q]).recently_added
+    bucketlists = Bucketlist.filter_by_name(params[:q]) if params[:q].present?
+    bucketlists = Bucketlist.paginate(params[:page], params[:limit]) if
+      params[:page].present? && params[:limit].present?
+    bucketlists ||= Bucketlist.all
   end
 end

--- a/spec/models/bucketlist_spec.rb
+++ b/spec/models/bucketlist_spec.rb
@@ -48,5 +48,17 @@ RSpec.describe Bucketlist, type: :model do
         end
       end
     end
+
+    describe '.paginate' do
+      before { Bucketlist.destroy_all }
+      let(:bucketlists) { create_list :bucketlist, 10 }
+      let(:page) { 2 }
+      let(:limit) { 2 }
+
+      it 'returns a strict bucketlist collection based on provided params' do
+        expect(Bucketlist.paginate(page, limit)).to match_array(
+          [bucketlists.third, bucketlists.fourth])
+      end
+    end
   end
 end


### PR DESCRIPTION
Implement pagination so that requests that look like this 

```
http://domain.com/bucketlists/page=2&limit=20
```

returns a collection containing the 11th to 20th bucketlist items
